### PR TITLE
style: revamp oferta-premiada layout

### DIFF
--- a/public/oferta-premiada/index.html
+++ b/public/oferta-premiada/index.html
@@ -5,19 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Stella Beghini | Vídeo Personalizado</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800&display=swap');
     :root{
-      --grad-a:#F58370;
-      --grad-b:#FFBF9A;
-      --bg:#f5f6f8;
-      --text:#1f2328;
-      --muted:#666;
-      --card:#fff;
+      /* paleta quente e agressiva */
+      --grad-a:#ff0055;
+      --grad-b:#ff8c00;
+      --bg:#0d0d0f;
+      --text:#f5f5f7;
+      --muted:#b3b3b6;
+      --card:#1a1a1e;
     }
     *{box-sizing:border-box}
     html,body{height:100%}
     body{
       margin:0;
-      font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Inter,Ubuntu,"Helvetica Neue",Arial,sans-serif;
+      font-family:'Poppins',-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Inter,Ubuntu,"Helvetica Neue",Arial,sans-serif;
       color:var(--text);
       background:var(--bg);
       line-height:1.5;
@@ -27,21 +29,22 @@
     /* Header */
     .header{
       position:sticky; top:0; z-index:10;
-      background:#fff;
-      border-bottom:1px solid #e9e9ee;
+      background:var(--card);
+      border-bottom:1px solid rgba(255,255,255,.08);
       display:flex; align-items:center; justify-content:center;
       height:64px; padding:0 16px;
     }
     .header img{height:36px; width:auto; display:block}
 
     /* Container */
-    .wrap{max-width:960px; margin:24px auto; padding:0 16px}
+    .wrap{max-width:960px; margin:32px auto; padding:0 16px}
 
     .hero{
       background:var(--card);
       border-radius:16px;
-      box-shadow:0 8px 24px rgba(0,0,0,.06);
+      box-shadow:0 8px 24px rgba(0,0,0,.4);
       overflow:hidden;
+      animation:fadeUp .5s ease both;
     }
     .media{
       position:relative; overflow:hidden;
@@ -55,22 +58,22 @@
       position:absolute; top:16px; right:16px;
       background:linear-gradient(135deg,var(--grad-a),var(--grad-b));
       color:#fff; padding:10px 14px; border-radius:999px; font-weight:700; font-size:14px;
-      box-shadow:0 6px 18px rgba(245,131,112,.35);
+      box-shadow:0 6px 18px rgba(255,0,85,.35);
     }
 
-    .content{padding:24px 20px 28px}
-    .headline{font-size:28px; font-weight:800; margin:0 0 6px}
-    .sub{color:var(--muted); font-size:17px; margin:0 0 14px}
+    .content{padding:32px 24px 36px}
+    .headline{font-size:32px; font-weight:800; margin:0 0 6px}
+    .sub{color:var(--muted); font-size:18px; margin:0 0 20px}
 
     .lucky{
-      margin:8px 0 18px; font-weight:700; font-size:15px;
-      color:#2b2b2f;
+      margin:8px 0 22px; font-weight:700; font-size:16px;
+      color:var(--text);
     }
 
     .price{
       display:flex; align-items:center; gap:12px; margin:12px 0 8px;
     }
-    .old{color:#999; text-decoration:line-through; font-weight:600}
+    .old{color:#888; text-decoration:line-through; font-weight:600}
     .new{
       font-weight:900; font-size:28px;
       background:linear-gradient(135deg,var(--grad-a),var(--grad-b));
@@ -84,37 +87,38 @@
       width:72px; aspect-ratio:1/1; border-radius:12px;
       background:linear-gradient(135deg,var(--grad-a),var(--grad-b));
       color:#fff; display:flex; flex-direction:column; align-items:center; justify-content:center;
-      box-shadow:0 10px 24px rgba(245,131,112,.35);
+      box-shadow:0 10px 24px rgba(255,0,85,.35);
     }
     .tval{font-size:26px; font-weight:800; line-height:1}
     .tlbl{text-transform:uppercase; font-size:11px; opacity:.9; margin-top:4px}
 
     .benefits{
-      margin:18px 0 8px; display:grid; gap:10px;
+      margin:24px 0 8px; display:grid; gap:12px;
     }
     .benefit{
-      background:#fafafc; border:1px solid #eee;
-      padding:12px 14px; border-radius:12px; font-size:15px;
+      background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.1);
+      padding:14px 16px; border-radius:12px; font-size:15px;
     }
 
-    .ctas{display:flex; flex-direction:column; gap:12px; margin-top:18px}
+    .ctas{display:flex; flex-direction:column; gap:14px; margin-top:24px}
     .btn{
       appearance:none; border:none; cursor:pointer; text-decoration:none; text-align:center;
-      font-weight:800; padding:16px 18px; border-radius:14px; transition:transform .06s ease, box-shadow .2s ease, opacity .2s ease;
+      font-weight:800; padding:16px 18px; border-radius:14px;
+      transition:transform .2s ease, box-shadow .3s ease, opacity .2s ease;
     }
     .btn-primary{
       color:#fff; background:linear-gradient(135deg,var(--grad-a),var(--grad-b));
-      box-shadow:0 14px 28px rgba(245,131,112,.35);
-      font-size:18px;
+      box-shadow:0 18px 36px rgba(255,0,85,.45);
+      font-size:19px;
     }
-    .btn-primary:hover{transform:translateY(-1px)}
+    .btn-primary:hover{transform:translateY(-3px) scale(1.02); box-shadow:0 22px 44px rgba(255,0,85,.6);}
     .btn-ghost{
-      background:#fff; border:1px solid #e5e6eb; color:#555; font-weight:700;
+      background:transparent; border:1px solid rgba(255,255,255,.2); color:var(--text); font-weight:700;
     }
-    .btn-ghost:hover{opacity:.9}
+    .btn-ghost:hover{background:rgba(255,255,255,.05); box-shadow:0 4px 12px rgba(0,0,0,.4);}
 
     .footnote{
-      margin-top:14px; color:#7a7b82; font-size:12.5px;
+      margin-top:14px; color:var(--muted); font-size:12.5px;
     }
 
     /* REVEAL OVERLAY */
@@ -125,25 +129,27 @@
       backdrop-filter:saturate(120%) blur(2px);
     }
     .card-reveal{
-      width:min(480px,92vw); background:#fff; border-radius:18px;
+      width:min(480px,92vw); background:var(--card); border-radius:18px;
       padding:26px 20px 22px; text-align:center;
-      box-shadow:0 24px 60px rgba(0,0,0,.45);
+      color:var(--text);
+      box-shadow:0 24px 60px rgba(0,0,0,.6);
       animation:pop .18s ease-out both;
     }
     @keyframes pop{from{transform:scale(.96); opacity:.0} to{transform:scale(1); opacity:1}}
+    @keyframes fadeUp{from{opacity:0; transform:translateY(20px)} to{opacity:1; transform:none}}
     .rev-title{font-size:22px; font-weight:900; margin:0 0 4px}
-    .rev-sub{color:#444; font-size:15px; margin:0 0 14px}
+    .rev-sub{color:var(--muted); font-size:15px; margin:0 0 14px}
     .rev-badge{
       display:inline-block; margin:8px 0 14px; font-weight:800; font-size:13px;
       background:linear-gradient(135deg,var(--grad-a),var(--grad-b)); color:#fff; padding:8px 12px; border-radius:999px;
-      box-shadow:0 8px 22px rgba(245,131,112,.35);
+      box-shadow:0 8px 22px rgba(255,0,85,.35);
     }
     .rev-btn{margin-top:6px}
 
     /* small */
     @media (max-width:520px){
-      .headline{font-size:24px}
-      .new{font-size:24px}
+      .headline{font-size:26px}
+      .new{font-size:26px}
       .tbox{width:66px}
     }
   </style>
@@ -219,9 +225,8 @@
   </main>
 
   <script>
-    // Número "sorteado" visual
-    function sorteia(min, max){ return Math.floor(Math.random()*(max-min+1))+min }
-    const lucky = sorteia(87, 999) // faixa crível
+    // Número fixo para mostrar ao usuário
+    const lucky = 1000
     document.getElementById('luckyNum').textContent = lucky.toLocaleString('pt-BR')
     document.getElementById('revLucky').textContent = lucky.toLocaleString('pt-BR')
 


### PR DESCRIPTION
## Summary
- redesign oferta-premiada with hot gradient palette, Poppins typography and stronger CTA styling
- add fade-up animations and darker overlay for a premium feel
- fix lucky number display to static 1.000

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f72222cc832d8d6eb8f1bf79531e