### PR TITLE
Add green status ring to purchase confirmation avatar

### DIFF
--- a/compra-aprovada/index.html
+++ b/compra-aprovada/index.html
@@ -24,6 +24,7 @@
     .avatar {
       width: 120px; height: 120px; border-radius: 50%;
       object-fit: cover; margin: 0 auto;
+      box-shadow: 0 0 0 4px #28a745;
     }
     .name { font-weight: 600; font-size: 18px; color: #333; margin-top: 10px; }
     .success { font-size: 17px; font-weight: 600; color: #008000; margin: 20px 0 10px; }


### PR DESCRIPTION
## Summary
- Add a green ring around the profile image on `/compra-aprovada` to mimic online status

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd60565f4832dbd8c1f4cdb6d68d5